### PR TITLE
Add cname option to ensure custom domain is set on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,4 @@ jobs:
           publish_branch: main
           external_repository: rocpy/rocpy.github.io
           publish_dir: ./site
+          cname: rocpy.org


### PR DESCRIPTION
## Changes
* Added "cname` option to the gh pages action in the `ci.yml` workflow. This ensure the custom domain for our GH page is set on every deploy.